### PR TITLE
Resolved issue with default role not set during :user model validation.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ActiveRecord::Base
-  before_create :set_default_role
+  before_validation :set_default_role
   acts_as_voter
 
   # Just For Devise


### PR DESCRIPTION
Rails 5 makes belongs_to association required by default. This change moves the setting of :role to just before model validations.