### PR TITLE
 Updated FactoryGirl to FactoryBot due to renaming by Thoughtbot.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ group :test do
 
   gem 'fuubar', '~> 2.2.0'
   gem 'database_cleaner', '~> 1.6'
-  gem 'factory_girl_rails', '~> 4.6'
+  gem 'factory_bot_rails'
   gem 'faker', '~> 1.7'
   gem 'shoulda', '~> 3.5.0'
   gem 'simplecov', '~> 0.14', require: false

--- a/spec/factories/roles.rb
+++ b/spec/factories/roles.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :role do
     sequence :name do |n|
       "#{Faker::Company.profession} #{n}"

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -4,7 +4,7 @@ RSpec.configure do |config|
   config.before(:suite) do
     begin
       DatabaseCleaner.start
-      FactoryGirl.lint unless config.files_to_run.one?
+      FactoryBot.lint unless config.files_to_run.one?
     ensure
       DatabaseCleaner.clean
     end


### PR DESCRIPTION
Thoughtbot renamed the project and the old name is deprecated. Per https://github.com/thoughtbot/factory_bot/blob/4-9-0-stable/UPGRADE_FROM_FACTORY_GIRL.md I updated. This removes a deprecation notice when running rspec.

Unfortunately my previous commit to resolve the default_role issue is also in this commit because I didn't use a branch.